### PR TITLE
dockerhub mirror support

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -61,7 +61,7 @@ def image_patch(containers, path_prefix):
     if "/" in image_mirrors and math_mirror==False:
       if image.startswith("docker.io/") or image.startswith("library/"):
         image = image_mirrors["/"] + replace_dockerhub_prfix(image)
-      else:
+      elif "." not in image.split("/")[0]:
         image =  image_mirrors["/"] + image
     json_patch.append({'op': 'replace', 'path': '%s/%d/image' % (path_prefix, idx), 'value': image})
   return json_patch


### PR DESCRIPTION
*Description of changes:*
1. add "/" as dockerhub mirror
now you can setup "/" as specific key name, it's used be dockerhub mirror
etc.
image_mirrors = {
  '/':'dockerhub mirror>',
  'gcr.io/': 'asia.gcr.io/',
  'k8s.gcr.io/': 'asia.gcr.io/google-containers/'
}
support: 
    docker.io/library/image:tag
    library/image:tag
    image:tag
    dockerhubid/image:tag

2. add private repo check , when you setup "/" as dockerhub mirror ,  webhook always  skip private repo image,  etc.  961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/eks/csi-liveness-probe

